### PR TITLE
Fix horizontal only translate()

### DIFF
--- a/src/SVGShape.php
+++ b/src/SVGShape.php
@@ -239,7 +239,7 @@ class SVGShape extends XMLElement
         if ($ty > 0) {
             $this->addTransform("translate($tx,$ty)");
         } else {
-            $this->addTransform("translate($tx);");
+            $this->addTransform("translate($tx)");
         }
 
         return $this;


### PR DESCRIPTION
The extra semicolon after the `translate()` breaks the translation. The shape won't be moved.